### PR TITLE
diva-aux: do not allocate an INTx IRQ when the interrupt pin is 0

### DIFF
--- a/hw/char/diva-gsp.c
+++ b/hw/char/diva-gsp.c
@@ -225,7 +225,18 @@ static void diva_aux_realize(PCIDevice *dev, Error **errp)
 
     pci->dev.config[PCI_CLASS_PROG] = 0x02;
     pci->dev.config[PCI_INTERRUPT_PIN] = 0x01;
-    pci->irq = pci_allocate_irq(&pci->dev);
+
+    /* PCI_INTERRUPT_PIN == 0 is a legal value meaning "device uses no
+     * INTx line" (PCI 3.0 sec 6.2.4) -- real Diva aux functions ship it
+     * (an HP e3000 A400 reads back Interrupt Pin 0 here).  pci_intx()
+     * computes config[PCI_INTERRUPT_PIN] - 1, so an unconditional
+     * pci_allocate_irq() would assert in hw/pci/pci.c at machine
+     * realization for such a device.  Follow the hw/misc/pci-testdev.c
+     * idiom: no pin, no allocation.  qemu_free_irq(NULL) in
+     * diva_aux_exit() is a safe no-op, so no guard is needed there. */
+    if (pci->dev.config[PCI_INTERRUPT_PIN] != 0) {
+        pci->irq = pci_allocate_irq(&pci->dev);
+    }
 
     memory_region_init(&pci->mem, OBJECT(pci), "mem", 16);
     pci_register_bar(&pci->dev, 0, PCI_BASE_ADDRESS_SPACE_MEMORY, &pci->mem);


### PR DESCRIPTION
Context: we are booting MPE/iX 7.5 (HP e3000 A400-class) on qemu-hppa + seabios-hppa, modeling the A400 against a real machine's measurements.

**Problem:** `pci_intx()` computes `config[PCI_INTERRUPT_PIN] - 1`, and `pci_allocate_irq()` asserts `0 <= intx && intx < PCI_NUM_PINS`. PCI_INTERRUPT_PIN = 0 is a *legal* PCI value ("device uses no interrupt pin", PCI 3.0 sec 6.2.4) — and a real A400's Diva aux function reads back exactly that (103c:128d, class 08/80, Interrupt Pin 0). Any move toward hardware-faithful modeling of that function makes `diva_aux_realize()`'s unconditional `pci_allocate_irq()` abort the whole VM at machine realization: `ERROR:hw/pci/pci.c: pci_allocate_irq: assertion failed: (0 <= intx && intx < 4)`. We hit this live while modeling the A400.

**Fix:** allocate the INTx IRQ only when the pin is nonzero, following the in-tree `hw/misc/pci-testdev.c` idiom ("no interrupt pin" => never allocate). `qemu_free_irq(NULL)` in the exit path is a safe no-op (`object_unref` NULL-checks), so teardown needs no guard. Zero behavior change for the current PIN=1 configuration — this is hardening for the legal PIN=0 case.

An alternative would be guarding inside `pci_allocate_irq()` itself (return NULL for pin 0); we chose the conservative device-local fix, happy to rework if you prefer the core version.